### PR TITLE
Update IndexType.java

### DIFF
--- a/lucene-index/src/main/java/org/neo4j/index/impl/lucene/IndexType.java
+++ b/lucene-index/src/main/java/org/neo4j/index/impl/lucene/IndexType.java
@@ -269,7 +269,7 @@ abstract class IndexType
             return (Query) value;
         }
         
-        QueryParser parser = new QueryParser( Version.LUCENE_30, keyOrNull, analyzer );
+        QueryParser parser = new QueryParser( Version.LUCENE_36, keyOrNull, analyzer );
         parser.setAllowLeadingWildcard( true );
         parser.setLowercaseExpandedTerms( toLowerCase );
         if ( contextOrNull != null && contextOrNull.getDefaultOperator() != null )


### PR DESCRIPTION
the version lower than `Version.LUCENE_31` will affect the  `autoGeneratePhraseQueries`
and `neo4j 2.3.3` is denpend on  `LUCENE_36`
